### PR TITLE
Update Kext to 202102

### DIFF
--- a/Installer/Package.pkgproj
+++ b/Installer/Package.pkgproj
@@ -514,39 +514,6 @@
 														</dict>
 														<dict>
 															<key>CHILDREN</key>
-															<array>
-																<dict>
-																	<key>CHILDREN</key>
-																	<array/>
-																	<key>GID</key>
-																	<integer>0</integer>
-																	<key>PATH</key>
-																	<string>data/OpenCore/X64/EFI/OC/Bootstrap/Bootstrap.efi</string>
-																	<key>PATH_TYPE</key>
-																	<integer>1</integer>
-																	<key>PERMISSIONS</key>
-																	<integer>420</integer>
-																	<key>TYPE</key>
-																	<integer>3</integer>
-																	<key>UID</key>
-																	<integer>0</integer>
-																</dict>
-															</array>
-															<key>GID</key>
-															<integer>0</integer>
-															<key>PATH</key>
-															<string>Bootstrap</string>
-															<key>PATH_TYPE</key>
-															<integer>2</integer>
-															<key>PERMISSIONS</key>
-															<integer>509</integer>
-															<key>TYPE</key>
-															<integer>2</integer>
-															<key>UID</key>
-															<integer>0</integer>
-														</dict>
-														<dict>
-															<key>CHILDREN</key>
 															<array/>
 															<key>GID</key>
 															<integer>0</integer>

--- a/Installer/data/AppleALC/source.txt
+++ b/Installer/data/AppleALC/source.txt
@@ -1,2 +1,2 @@
-https://github.com/acidanthera/AppleALC/releases/download/1.5.6/AppleALC-1.5.6-RELEASE.zip
-2e9b9d976886810d94002937864abd497e7f8f01b6a4405fc8eda3e6c54bbf0b
+https://github.com/acidanthera/AppleALC/releases/download/1.5.7/AppleALC-1.5.7-RELEASE.zip
+f1683bbfd89f75cc6669abe934f7bd8c47790eb398bce339aafcc9f6fa056d91

--- a/Installer/data/BrcmPatchRAM/source.txt
+++ b/Installer/data/BrcmPatchRAM/source.txt
@@ -1,2 +1,2 @@
-https://github.com/acidanthera/BrcmPatchRAM/releases/download/2.5.5/BrcmPatchRAM-2.5.5-RELEASE.zip
-2b3475892ffa26d6a8bffa6575f200ce28f2d76ce8a2c6d9dd6cb5588c6258ab
+https://github.com/acidanthera/BrcmPatchRAM/releases/download/2.5.6/BrcmPatchRAM-2.5.6-RELEASE.zip
+ed2dd08bbffa5016655d11db7b766de632c9850ad36fa5ec7827d51dae63a4ef

--- a/Installer/data/Lilu/source.txt
+++ b/Installer/data/Lilu/source.txt
@@ -1,2 +1,2 @@
-https://github.com/acidanthera/Lilu/releases/download/1.5.0/Lilu-1.5.0-RELEASE.zip
-126e44a0ed0e1f59a02843ae1a8ea6111e56b379359333f4e9dea0e7ed757e07
+https://github.com/acidanthera/Lilu/releases/download/1.5.1/Lilu-1.5.1-RELEASE.zip
+d57dd2732ee1062203ca6ea184a994b84cbe6f09b7ddd31480a8d0bc0ff69439

--- a/Installer/data/OpenCore/source.txt
+++ b/Installer/data/OpenCore/source.txt
@@ -1,2 +1,2 @@
-https://github.com/acidanthera/OpenCorePkg/releases/download/0.6.5/OpenCore-0.6.5-RELEASE.zip
-bcbc1b783ab7957973fd13ea4a5d120b0deb063120ff98a863fa7dc34c32c5c3
+https://github.com/acidanthera/OpenCorePkg/releases/download/0.6.6/OpenCore-0.6.6-RELEASE.zip
+c22f34f594d5c29b991d25dfc2075de523432ffa91588c2216e4b8963c7a8f74

--- a/Installer/data/VirtualSMC/source.txt
+++ b/Installer/data/VirtualSMC/source.txt
@@ -1,2 +1,2 @@
-https://github.com/acidanthera/VirtualSMC/releases/download/1.1.9/VirtualSMC-1.1.9-RELEASE.zip
-adb07229158e809eacfae6e7b7f8fe84da30a862703efc553657cc7aef69963a
+https://github.com/acidanthera/VirtualSMC/releases/download/1.2.0/VirtualSMC-1.2.0-RELEASE.zip
+a8a3554460038985254442ba826acbc6fb7899acb4ce220cce08eebc1625dbc6

--- a/Installer/data/WhateverGreen/source.txt
+++ b/Installer/data/WhateverGreen/source.txt
@@ -1,2 +1,2 @@
-https://github.com/acidanthera/WhateverGreen/releases/download/1.4.6/WhateverGreen-1.4.6-RELEASE.zip
-c6317b516219f525f9bc64b25fde15275279d42b2968af3c5d5a6b3569683193
+https://github.com/acidanthera/WhateverGreen/releases/download/1.4.7/WhateverGreen-1.4.7-RELEASE.zip
+45a877109faad7897c25229bf4fe419724fc93ad12f53193f0f7875120b2cfb1

--- a/OC/config.plist
+++ b/OC/config.plist
@@ -486,6 +486,10 @@
 		<dict>
 			<key>HibernateMode</key>
 			<string>Auto</string>
+			<key>LauncherOption</key>
+			<string>Full</string>
+			<key>LauncherPath</key>
+			<string>Default</string>
 			<key>PickerAttributes</key>
 			<integer>19</integer>
 			<key>PickerMode</key>
@@ -503,8 +507,6 @@
 			<true/>
 			<key>BlacklistAppleUpdate</key>
 			<true/>
-			<key>BootProtect</key>
-			<string>Bootstrap</string>
 			<key>ScanPolicy</key>
 			<integer>0</integer>
 			<key>SecureBootModel</key>
@@ -521,10 +523,10 @@
 			<dict/>
 			<key>7C436110-AB2A-4BBB-A880-FE41995C9F82</key>
 			<dict>
-				<key>run-efi-updater</key>
-				<string>No</string>
 				<key>boot-args</key>
 				<string>alcid=11 agdpmod=ignore -disablegfxfirmware</string>
+				<key>run-efi-updater</key>
+				<string>No</string>
 			</dict>
 		</dict>
 		<key>WriteFlash</key>


### PR DESCRIPTION
More tests may be needed as the `Bootstrap.efi` is removed in OpenCore 0.6.6 (and corresponding config.plist options are changed)


I suggest `reset NVRAM` manually after installing the pkg, but before rebooting. (So don' rely on OpenCore's reset NVRAM)
Or there might be issues that booting device cannot be found (due to the previous NVRAM settings for OC 0.6.5 bootstrap boot settings.) 