### PR TITLE
config: fix show osc about KeyMergeThreshold when boot

### DIFF
--- a/OC/config.plist
+++ b/OC/config.plist
@@ -586,8 +586,6 @@
 		<dict>
 			<key>KeyForgetThreshold</key>
 			<integer>5</integer>
-			<key>KeyMergeThreshold</key>
-			<integer>2</integer>
 			<key>KeySupport</key>
 			<true/>
 			<key>KeySupportMode</key>


### PR DESCRIPTION
After install version 3.0.1, the following warning will be displayed every time the system boot:
`OSC: No schema fom KeyMergeThreshold at 1 index, context <Input>!`

The reason is that the support for KeyMergeThreshold has been removed since OpenCore 0.6.7.
[OpenCore changelog](https://github.com/acidanthera/OpenCorePkg/blob/master/Changelog.md)