### PR TITLE
Monterey 12.0.1 support for intel/brcm cards.

### DIFF
--- a/Installer/Package.pkgproj
+++ b/Installer/Package.pkgproj
@@ -9971,6 +9971,22 @@
 																	<integer>0</integer>
 																</dict>
 																<dict>
+																	<key>CHILDREN</key>
+																	<array/>
+																	<key>GID</key>
+																	<integer>0</integer>
+																	<key>PATH</key>
+																	<string>data/BrcmPatchRAM/BlueToolFixup.kext.Priority.txt</string>
+																	<key>PATH_TYPE</key>
+																	<integer>1</integer>
+																	<key>PERMISSIONS</key>
+																	<integer>420</integer>
+																	<key>TYPE</key>
+																	<integer>3</integer>
+																	<key>UID</key>
+																	<integer>0</integer>
+																</dict>
+																<dict>
 																	<key>BUNDLE_CAN_DOWNGRADE</key>
 																	<false/>
 																	<key>BUNDLE_POSTINSTALL_PATH</key>

--- a/Installer/data/AppleALC/source.txt
+++ b/Installer/data/AppleALC/source.txt
@@ -1,2 +1,2 @@
-https://github.com/acidanthera/AppleALC/releases/download/1.6.5/AppleALC-1.6.5-RELEASE.zip
-d981fb7d568fbb4a946cd72361149ca1bafe8771b52de9cf2a137da906d181fc
+https://github.com/acidanthera/AppleALC/releases/download/1.6.6/AppleALC-1.6.6-RELEASE.zip
+f0ca5f5787cb81c04791411f113cdf67a15c1dafccfb930d73a536276e7073bf

--- a/Installer/data/BrcmPatchRAM/source.txt
+++ b/Installer/data/BrcmPatchRAM/source.txt
@@ -1,2 +1,2 @@
-https://github.com/acidanthera/BrcmPatchRAM/releases/download/2.6.0/BrcmPatchRAM-2.6.0-RELEASE.zip
-d0822c2a1f32ab2adcaed1848b8a3277bace3b2d28d1acf25ee268bba4f83290
+https://github.com/dortania/build-repo/releases/download/BrcmPatchRAM-8b5c9d7/BrcmPatchRAM-2.6.1-RELEASE.zip
+06210e1b45dbf0605c4961b2876f5f8d18c0d53ab1d64088be604510f7a67148

--- a/Installer/data/BrcmPatchRAM/source.txt
+++ b/Installer/data/BrcmPatchRAM/source.txt
@@ -1,2 +1,2 @@
-https://github.com/dortania/build-repo/releases/download/BrcmPatchRAM-8b5c9d7/BrcmPatchRAM-2.6.1-RELEASE.zip
-06210e1b45dbf0605c4961b2876f5f8d18c0d53ab1d64088be604510f7a67148
+https://github.com/acidanthera/BrcmPatchRAM/releases/download/2.6.1/BrcmPatchRAM-2.6.1-RELEASE.zip
+df8feb506f0cb48f85f93190b7defe4ed1376a85e3570fc5bbaf0ea724d9392e

--- a/Installer/data/Lilu/source.txt
+++ b/Installer/data/Lilu/source.txt
@@ -1,2 +1,2 @@
-https://github.com/acidanthera/Lilu/releases/download/1.5.6/Lilu-1.5.6-RELEASE.zip
-c9a3b248b7950dab1c8013f4eb7631b29ee69ea8ab9e4d2f575cce49d896dfa1
+https://github.com/acidanthera/Lilu/releases/download/1.5.7/Lilu-1.5.7-RELEASE.zip
+5637f9f03680c4c2dec4c54d92acbda65e70009090b404d28b2a266e113d9ee8

--- a/Installer/data/OpenCore/source.txt
+++ b/Installer/data/OpenCore/source.txt
@@ -1,2 +1,2 @@
-https://github.com/acidanthera/OpenCorePkg/releases/download/0.7.4/OpenCore-0.7.4-RELEASE.zip
-db7b04e68acf40c1c79a78cb5211a36f33c8335078fa4af736b28b590f30cee6
+https://github.com/acidanthera/OpenCorePkg/releases/download/0.7.5/OpenCore-0.7.5-RELEASE.zip
+57480902cc78120fb2c09ba7dda3730862bd59924e9b227933186195e51e148f

--- a/Installer/data/WhateverGreen/source.txt
+++ b/Installer/data/WhateverGreen/source.txt
@@ -1,2 +1,2 @@
-https://github.com/acidanthera/WhateverGreen/releases/download/1.5.4/WhateverGreen-1.5.4-RELEASE.zip
-5651aeacf0f5f1c84ef1418255cd7df7619fb16e02091c85fd7d90c810bf71e6
+https://github.com/acidanthera/WhateverGreen/releases/download/1.5.5/WhateverGreen-1.5.5-RELEASE.zip
+7082600515f41fa5a2d83d59ca27ce3aba0ffe9b8554c5b69dba4ec01c48f682


### PR DESCRIPTION
- [x] update bluetoolfixup v2.6.1-dev for basic bluetooth support in Monterey 12.0.1 (intel/brcm cards)
- [x] set bluetoolfixup kext priority to be the last to prevent boot loop (intel cards. As brcm cards already set before)
- [x] update with the acidanthera official 2021.11 release (intel/brcm cards)
- [ ] two-way airdrop. Should wait for potential updates in BrcmRamPatch kext (brcm cards. Intel cards is not supported)

Should fix https://github.com/osy/HaC-Mini/issues/942 https://github.com/osy/HaC-Mini/issues/953